### PR TITLE
Fix ssl bug

### DIFF
--- a/uw/log_to_ga.py
+++ b/uw/log_to_ga.py
@@ -8,6 +8,10 @@
 #  Contributors:
 #  Phil Hopper <phillip_hopper@wycliffeassociates.org>
 #
+# References:
+#    https://developers.google.com/analytics/devguides/collection/protocol/v1/reference
+#    https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide
+#
 
 import os
 import re
@@ -86,7 +90,7 @@ def process_this_line(logline):
     # send_hit_to_ga(requestparts[1], timestamp)
 
     # HTTP_PORT or HTTPS_PORT
-    with GoogleConnection('www.google-analytics.com', httplib.HTTPS_PORT) as connection:
+    with GoogleConnection('ssl.google-analytics.com', httplib.HTTPS_PORT) as connection:
 
         payload = ['v=1', 'tid=' + propertyID, 'cid=555', 't=pageview', 'dh=' + hostName,
                    'dp=' + requestparts[1]]


### PR DESCRIPTION
It seems google recently made a change and is only accepting https posts on ssl.google-analytics.com, not www.google-analytics.com